### PR TITLE
Fixing weak-safety bug in Random template

### DIFF
--- a/circuits/perlin/perlin.circom
+++ b/circuits/perlin/perlin.circom
@@ -21,7 +21,7 @@ template Random() {
     mimc.ins[2] <== in[2];
     mimc.k <== KEY;
 
-    component num2Bits = Num2Bits(254);
+    component num2Bits = Num2Bits_strict();
     num2Bits.in <== mimc.outs[0];
     out <== num2Bits.out[3] * 8 + num2Bits.out[2] * 4 + num2Bits.out[1] * 2 + num2Bits.out[0];
 }


### PR DESCRIPTION
### Potential safety bug in Random template:

The template Random (perlin.circom) presents a safety vulnerability that may affect to the behavior of the circuit. The template do not satisfy the weak safety property ([https://www.techrxiv.org/articles/preprint/CIRCOM_A_Robust_and_Scalable_Language_for_Building_Complex_Zero-Knowledge_Circuits/19374986/1](url), [https://0xparc.org/blog/ecne](url)) as it accepts multiple outputs for a single input.

This template receives three inputs x, y, z and calls to the component MiMCSponge to generate a random output mimc.outs that then uses to generate a value between [0, 15]. 
However, the template contains a call to NumBits(254) that is potentially unsafe as for any input value in between [0, 7059779437489773633646340506914701874769131765994106666166191815402473914367] the circuit Num2Bits(254) accepts two outputs for that input.

For example, the circuit Num2Bits(254) accepts for the input in = 3 the possible outputs:
- Out1: 110000...000
- Out2: 00100000000000000000000000001111110010011010111110000111110000101000100100001110100111011001111000010010000101111100110000010100101110100001101010000001100000010110110110100010000010100001110110010100000001011000110010000111010011100111001000100110000011

as both of them are binary representations of the value 3 (in the second case it corresponds to the binary representation of the value p + 3 with p being the prime value in which the field is defined).
This way, the Random template accepts both the outputs 3 and 4, which is potentially dangerous.

In order to fix this issue, we substitute the call to Num2Bits(254) by a call to Num2Bits_strict(). This second template adds a call to AliasCheck that ensures that the template only accepts outputs that correspond with the binary representation of a number x such that x <= p-1. This way, in the previous case the second possible solution Out2 is not valid as it represents the number p + 3.